### PR TITLE
Import Advent2022 solutions to IAdventPuzzle, and improve helpers

### DIFF
--- a/Advent of Code/Advent of Code.csproj
+++ b/Advent of Code/Advent of Code.csproj
@@ -9,133 +9,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Advent2022\**" />
     <Compile Remove="Advent2023\**" />
-    <EmbeddedResource Remove="Advent2022\**" />
+    <Compile Remove="old\**" />
     <EmbeddedResource Remove="Advent2023\**" />
-    <None Remove="Advent2022\**" />
+    <EmbeddedResource Remove="old\**" />
     <None Remove="Advent2023\**" />
+    <None Remove="old\**" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Advent2024\input\01.txt">
+    <Content Include="Advent2022\input\*.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Advent2024\input\02.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\03.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\04.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\05.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\06.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\07.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\08.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\09.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\10.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\11.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\12.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\13.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\14.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\15.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\16.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\17.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\18.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\19.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\20.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\21.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\22.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\23.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\24.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\25.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample01.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample05.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample06.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample07.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample08.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample09.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample10.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample11.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample12.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample13.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample15.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample16.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample21.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample22.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Advent2024\input\sample23.txt">
+    <Content Include="Advent2024\input\*.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Advent of Code/Advent.cs
+++ b/Advent of Code/Advent.cs
@@ -4,23 +4,23 @@ namespace Advent_of_Code;
 
 internal static class Program
 {
-    private static async Task Main(string[] args)
+    private static void Main(string[] args)
     {
         var totalElapsed = 0L;
-        foreach (var puzzle in IAdventPuzzle.GetPuzzles(nameof(Advent2024)))
+        foreach (var puzzle in IAdventPuzzle.GetPuzzles(nameof(Advent2022)))
         {
             for (int part = 1; part <= (puzzle.Name == "Day25" ? 1 : 2); part++)
             {
                 var solver = IAdventPuzzle.Solver(puzzle, part);
 
-                using var sample = await InputHelper.Create(puzzle, "sample");
+                using var sample = InputHelper.Create(puzzle, "sample");
                 if (sample is not null)
                 {
                     var sampleResult = solver.Solve(sample);
                     Console.WriteLine($"{puzzle.Name} part{part}: SAMPLE = {sampleResult}");
                 }
 
-                using var input = await InputHelper.Create(puzzle);
+                using var input = InputHelper.Create(puzzle);
                 if (input is not null)
                 {
                     var timer = Stopwatch.StartNew();

--- a/Advent of Code/Advent2022/Day01.cs
+++ b/Advent of Code/Advent2022/Day01.cs
@@ -1,0 +1,11 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day01(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        var elves = inputHelper.EachSection(section => section.Sum(Convert.ToInt64));
+
+        return isPart1 ? elves.Max().ToString() : elves.Order().TakeLast(3).Sum().ToString();
+    }
+}

--- a/Advent of Code/Advent2022/Day02.cs
+++ b/Advent of Code/Advent2022/Day02.cs
@@ -1,0 +1,15 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day02(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper) =>
+        inputHelper.EachLine(line => (isPart1, line) switch {
+            (true, "A X") => 3 + 1, (true, "B X") => 0 + 1, (true, "C X") => 6 + 1,
+            (true, "A Y") => 6 + 2, (true, "B Y") => 3 + 2, (true, "C Y") => 0 + 2,
+            (true, "A Z") => 0 + 3, (true, "B Z") => 6 + 3, (true, "C Z") => 3 + 3,
+            (false, "A X") => 0 + 3, (false, "B X") => 0 + 1, (false, "C X") => 0 + 2,
+            (false, "A Y") => 3 + 1, (false, "B Y") => 3 + 2, (false, "C Y") => 3 + 3,
+            (false, "A Z") => 6 + 2, (false, "B Z") => 6 + 3, (false, "C Z") => 6 + 1,
+            _ => -99999
+        }).Sum().ToString();
+}

--- a/Advent of Code/Advent2022/Day03.cs
+++ b/Advent of Code/Advent2022/Day03.cs
@@ -1,0 +1,13 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day03(bool isPart1) : IAdventPuzzle
+{
+    private static readonly Dictionary<char, int> priority = " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        .Select((c, i) => (c, i)).ToDictionary(x => x.c, x => x.i);
+
+    public string Solve(InputHelper inputHelper) => isPart1
+        ? inputHelper.EachLine(line => line.Take(line.Length / 2).Intersect(line.Skip(line.Length / 2)).Single())
+            .Sum(x => priority[x]).ToString()
+        : inputHelper.EachLine().Chunk(3)
+            .Sum(l => priority[l[0].Intersect(l[1]).Intersect(l[2]).Single()]).ToString();
+}

--- a/Advent of Code/Advent2022/Day04.cs
+++ b/Advent of Code/Advent2022/Day04.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Advent_of_Code.Advent2022;
+
+public partial class Day04(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        var ranges = inputHelper.EachMatchGroup(Assignments(), matches => matches[1..].Select(int.Parse).ToArray());
+
+        return isPart1
+            ? ranges.Count(r => r[0] <= r[2] && r[3] <= r[1] || r[2] <= r[0] && r[1] <= r[3]).ToString()
+            : ranges.Count(r => r[1] >= r[2] && r[0] <= r[3]).ToString();
+    }
+
+    [GeneratedRegex(@"(\d+)-(\d+),(\d+)-(\d+)")]
+    private static partial Regex Assignments();
+}

--- a/Advent of Code/Advent2022/Day05.cs
+++ b/Advent of Code/Advent2022/Day05.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Advent_of_Code.Advent2022;
+
+public partial class Day05(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        var grid = new GridHelper(inputHelper.EachLineInSection(line => line));
+        var stacks = Enumerable.Range(0, (grid.Size[1] + 1) / 4)
+            .Select(x => Enumerable.Range(0, grid.Size[0] - 1).Reverse().Select(y => grid[[y, x * 4 + 1]]).TakeWhile(c => c != ' ').ToList())
+            .ToArray();
+
+        foreach (var (n, from, to) in inputHelper.EachMatchGroup(Instruction(), match => match[1..].Select(int.Parse).ToArray()).Select(m => (m[0], m[1] - 1, m[2] - 1)))
+        {
+            stacks[to].AddRange(isPart1
+                ? stacks[from].TakeLast(n).Reverse()
+                : stacks[from].TakeLast(n));
+            stacks[from].RemoveRange(stacks[from].Count - n, n);
+        }
+        return new string(stacks.Select(x => x[^1]).ToArray());
+    }
+
+    [GeneratedRegex(@"move (\d+) from (\d+) to (\d+)")]
+    private static partial Regex Instruction();
+}

--- a/Advent of Code/Advent2022/Day06.cs
+++ b/Advent of Code/Advent2022/Day06.cs
@@ -1,0 +1,16 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day06(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        var dataStream = inputHelper.EachLine().Single();
+        var markerLength = isPart1 ? 4 : 14;
+        for (var startIndex = 0; startIndex < dataStream.Length; startIndex++)
+        {
+            if (dataStream.Skip(startIndex).Take(markerLength).Distinct().Count() == markerLength)
+                return $"{startIndex + markerLength}";
+        }
+        return "none found";
+    }
+}

--- a/Advent of Code/Advent2022/Day07.cs
+++ b/Advent of Code/Advent2022/Day07.cs
@@ -1,0 +1,35 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day07(bool isPart1) : IAdventPuzzle
+{
+    private sealed record Dir(string Name, Dir? Parent)
+    {
+        public Dictionary<string, Dir> Children { get; } = [];
+        public Dictionary<string, long> Files { get; } = [];
+        public void Add(string dirName) => Children.TryAdd(dirName, new Dir(dirName, this));
+        public void Add(string filename, long size) => Files.TryAdd(filename, size);
+        public long Size => Files.Sum(kv => kv.Value) + Children.Sum(kv => kv.Value.Size);
+        public IEnumerable<Dir> Descendants => Children.Values.Concat(Children.Values.SelectMany(dir => dir.Descendants));
+    }
+
+    public string Solve(InputHelper inputHelper)
+    {
+        var root = new Dir("/", null);
+        var cwd = root;
+        foreach (var line in inputHelper.EachLine())
+        {
+            switch (line.Split(' '))
+            {
+                case ["$", "ls"]: continue;
+                case ["$", "cd", ".."]: cwd = cwd.Parent ?? root; break;
+                case ["$", "cd", "/"]: cwd = root; break;
+                case ["$", "cd", var child]: cwd = cwd.Children[child]; break;
+                case ["dir", var dirName]: cwd.Add(dirName); break;
+                case [var fileSize, var fileName]: cwd.Add(fileName, long.Parse(fileSize)); break;
+            }
+        }
+        return isPart1
+            ? root.Descendants.Where(dir => dir.Size <= 100_000).Sum(dir => dir.Size).ToString()
+            : root.Descendants.Where(dir => 70_000_000 - root.Size + dir.Size >= 30_000_000).Min(dir => dir.Size).ToString();
+    }
+}

--- a/Advent of Code/Advent2022/Day08.cs
+++ b/Advent of Code/Advent2022/Day08.cs
@@ -1,0 +1,49 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day08(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        var trees = new GridHelper<int>(inputHelper.EachLine(line => line.Select(c => c - '0')));
+
+        return isPart1
+            ? "NSEW".Aggregate(Enumerable.Empty<int[]>(),
+                (vis, orientation) => vis.Union(CheckVisibility(trees, orientation), trees)).Count().ToString()
+            : trees.Points.Max(p => ScenicScore(trees, p[1], p[0])).ToString();
+    }
+
+    private static IEnumerable<int[]> CheckVisibility(GridHelper<int> trees, char orientation)
+    {
+        var aRange = Enumerable.Range(0, trees.Size[0]);
+        var bRange = Enumerable.Range(0, trees.Size[1]);
+        if ("EW".Contains(orientation)) // vertical, so swap x and y (swap them back again later)
+            (aRange, bRange) = (bRange, aRange);
+        if ("ES".Contains(orientation)) // negative, so reverse the inner loop
+            bRange = bRange.Reverse();
+
+        foreach (var a in aRange)
+        {
+            var maxHeight = -1;
+            foreach (var b in bRange)
+            {
+                var (x, y) = "EW".Contains(orientation) ? (a, b) : (b, a);
+                if (trees[[y, x]] > maxHeight)
+                {
+                    maxHeight = trees[[y, x]];
+                    yield return [y, x];
+                }
+            }
+        }
+    }
+    private static int ScenicScore(GridHelper<int> trees, int x, int y)
+    {
+        var (xMax, yMax) = (trees.Size[1] - 1, trees.Size[0] - 1);
+        int n, s, e, w; // look in each direction until we find a value >= our start tree (or find the edge)
+        for (e = x + 1; e < xMax && trees[[y, e]] < trees[[y, x]]; e++) ;
+        for (w = x - 1; w > 0 && trees[[y, w]] < trees[[y, x]]; w--) ;
+        for (s = y + 1; s < yMax && trees[[s, x]] < trees[[y, x]]; s++) ;
+        for (n = y - 1; n > 0 && trees[[n, x]] < trees[[y, x]]; n--) ;
+        return (y - n) * (y - s) * (x - e) * (x - w);
+    }
+
+}

--- a/Advent of Code/Advent2022/Day09.cs
+++ b/Advent of Code/Advent2022/Day09.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day09(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day10.cs
+++ b/Advent of Code/Advent2022/Day10.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day10(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day11.cs
+++ b/Advent of Code/Advent2022/Day11.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day11(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day12.cs
+++ b/Advent of Code/Advent2022/Day12.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day12(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day13.cs
+++ b/Advent of Code/Advent2022/Day13.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day13(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day14.cs
+++ b/Advent of Code/Advent2022/Day14.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day14(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day15.cs
+++ b/Advent of Code/Advent2022/Day15.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day15(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day16.cs
+++ b/Advent of Code/Advent2022/Day16.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day16(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day17.cs
+++ b/Advent of Code/Advent2022/Day17.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day17(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day18.cs
+++ b/Advent of Code/Advent2022/Day18.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day18(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day19.cs
+++ b/Advent of Code/Advent2022/Day19.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day19(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day20.cs
+++ b/Advent of Code/Advent2022/Day20.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day20(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day21.cs
+++ b/Advent of Code/Advent2022/Day21.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day21(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day22.cs
+++ b/Advent of Code/Advent2022/Day22.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day22(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day23.cs
+++ b/Advent of Code/Advent2022/Day23.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day23(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day24.cs
+++ b/Advent of Code/Advent2022/Day24.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day24(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2022/Day25.cs
+++ b/Advent of Code/Advent2022/Day25.cs
@@ -1,0 +1,9 @@
+﻿namespace Advent_of_Code.Advent2022;
+
+public class Day25(bool isPart1) : IAdventPuzzle
+{
+    public string Solve(InputHelper inputHelper)
+    {
+        return string.Empty;
+    }
+}

--- a/Advent of Code/Advent2024/Day06.cs
+++ b/Advent of Code/Advent2024/Day06.cs
@@ -2,12 +2,12 @@
 
 public class Day06(bool isPart1) : IAdventPuzzle
 {
-    private Cartesian<int>.GridHelper? grid;
+    private GridHelper? grid;
     private Dictionary<int, HashSet<int>> wallsByRow = [];
     private Dictionary<int, HashSet<int>> wallsByCol = [];
     public string Solve(InputHelper inputHelper)
     {
-        grid = new(inputHelper.EachLine(line => line));
+        grid = new(inputHelper.EachLine());
         wallsByRow = grid['#'].GroupBy(p => p[0], p => p[1]).ToDictionary(g => g.Key, g => g.ToHashSet());
         wallsByCol = grid['#'].GroupBy(p => p[1], p => p[0]).ToDictionary(g => g.Key, g => g.ToHashSet());
         var guard0 = grid['^'].Single();

--- a/Advent of Code/Advent2024/Day08.cs
+++ b/Advent of Code/Advent2024/Day08.cs
@@ -4,7 +4,7 @@ public class Day08(bool isPart1) : IAdventPuzzle
 {
     public string Solve(InputHelper inputHelper)
     {
-        var antennae = new Cartesian<int>.GridHelper(inputHelper.EachLine(x => x));
+        var antennae = new GridHelper(inputHelper.EachLine());
         var pairs = antennae.Items.Where(i => i != '.').ToDictionary(i => i, i =>
             antennae[i].SelectMany(a => antennae[i], (a, b) => (a, b)).Where(p => antennae.Compare(p.a, p.b) < 0));
         var antinodes = pairs.SelectMany(p => p.Value)

--- a/Advent of Code/Advent2024/Day10.cs
+++ b/Advent of Code/Advent2024/Day10.cs
@@ -4,7 +4,7 @@ public class Day10(bool isPart1) : IAdventPuzzle
 {
     public string Solve(InputHelper inputHelper)
     {
-        var grid = new Cartesian<int>.GridHelper<char, int>(inputHelper.EachLine(line => line), c => c - '0');
+        var grid = new GridHelper<int>(inputHelper.EachLine(line => line.Select(c => c - '0')));
         var score = new Dictionary<int[], IEnumerable<int[]>>(grid);
         var rating = new Dictionary<int[], int>(grid);
 

--- a/Advent of Code/Advent2024/Day12.cs
+++ b/Advent of Code/Advent2024/Day12.cs
@@ -4,7 +4,7 @@ public class Day12(bool isPart1) : IAdventPuzzle
 {
     public string Solve(InputHelper inputHelper)
     {
-        var grid = new Cartesian<int>.GridHelper(inputHelper.EachLine(line => line));
+        var grid = new GridHelper(inputHelper.EachLine());
         var corners = new[] { 1, 0, 0, 1, 1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 1 }.Chunk(2).Chunk(2);
 
         var perimeters = new List<int>();

--- a/Advent of Code/Advent2024/Day16.cs
+++ b/Advent of Code/Advent2024/Day16.cs
@@ -19,7 +19,7 @@ public class Day16(bool isPart1) : IAdventPuzzle
 
     public string Solve(InputHelper inputHelper)
     {
-        var grid = new Cartesian<int>.GridHelper(inputHelper.EachLine(line => line));
+        var grid = new GridHelper(inputHelper.EachLine());
         var start = grid['S'].Single();
 
         var reachable = new Dictionary<Tile, int>();

--- a/Advent of Code/Advent2024/Day18.cs
+++ b/Advent of Code/Advent2024/Day18.cs
@@ -6,7 +6,7 @@ public class Day18(bool isPart1) : IAdventPuzzle
     {
         var obstacles = inputHelper.EachLine(line => line.Split(',').Select(int.Parse).ToArray()).ToArray();
 
-        var comparer = new Cartesian<int>.GridHelper();
+        var comparer = new GridHelper();
         if (isPart1) return FindPath(obstacles[..1024].ToHashSet(comparer), comparer).ToString();
 
         var (min, max) = (1024, obstacles.Length);

--- a/Advent of Code/Advent2024/Day20.cs
+++ b/Advent of Code/Advent2024/Day20.cs
@@ -4,7 +4,7 @@ public class Day20(bool isPart1) : IAdventPuzzle
 {
     public string Solve(InputHelper inputHelper)
     {
-        var racetrack = new Cartesian<int>.GridHelper(inputHelper.EachLine(x => x));
+        var racetrack = new GridHelper(inputHelper.EachLine());
         var (start, goal) = (racetrack['S'].Single(), racetrack['E'].Single());
 
         var search = new PriorityQueue<int[], int>([(start, 0)]);

--- a/Advent of Code/Advent2024/Day21.cs
+++ b/Advent of Code/Advent2024/Day21.cs
@@ -4,7 +4,7 @@ namespace Advent_of_Code.Advent2024;
 
 public partial class Day21(bool isPart1) : IAdventPuzzle
 {
-    private sealed class RobotArm(Cartesian<int>.GridHelper grid, Func<IReadOnlyDictionary<(char, char), long>, IReadOnlyDictionary<(char, char), long>>? presequencer = null)
+    private sealed class RobotArm(GridHelper grid, Func<IReadOnlyDictionary<(char, char), long>, IReadOnlyDictionary<(char, char), long>>? presequencer = null)
     {
         private sealed class Orderer(string order) : IComparer<char>
         {
@@ -63,7 +63,7 @@ public partial class Day21(bool isPart1) : IAdventPuzzle
 
     public string Solve(InputHelper inputHelper)
     {
-        var grid = new Cartesian<int>.GridHelper(["789", "456", "123", " 0A", " ^B", "<v>"]);
+        var grid = new GridHelper(["789", "456", "123", " 0A", " ^B", "<v>"]);
         var robots = new List<RobotArm>() { new(grid) };
         for (var i = 0; i < 25; i++)
             robots.Add(new(grid, robots[i].Sequences));

--- a/Advent of Code/Advent2024/Day25.cs
+++ b/Advent of Code/Advent2024/Day25.cs
@@ -4,7 +4,7 @@ public class Day25(bool isPart1) : IAdventPuzzle
 {
     public string Solve(InputHelper inputHelper)
     {
-        var schematics = inputHelper.EachSection(section => new Cartesian<int>.GridHelper(section));
+        var schematics = inputHelper.EachSection(section => new GridHelper(section));
         var codes = schematics.GroupBy(grid => grid[[0, 0]],
                 grid => Enumerable.Range(0, 5).Select(x => grid['#'].Count(xy => xy[1] == x)))
             .ToDictionary(g => g.Key, g => g.AsEnumerable());

--- a/Advent of Code/IAdventPuzzle.cs
+++ b/Advent of Code/IAdventPuzzle.cs
@@ -4,9 +4,14 @@ public interface IAdventPuzzle
 {
     string Solve(InputHelper inputHelper);
 
-    static IEnumerable<Type> GetPuzzles(string annualNamespace) =>
+    public static IEnumerable<Type> GetPuzzles(string annualNamespace) =>
         Enumerable.Range(1, 25).Select(day => Type.GetType($"Advent_of_Code.{annualNamespace}.Day{day:D2}")).OfType<Type>();
 
-    static IAdventPuzzle Solver(Type type, int part) => Activator.CreateInstance(type, [part == 1]) as IAdventPuzzle
+    public static IAdventPuzzle Solver(Type type, int part) => Activator.CreateInstance(type, [part == 1]) as IAdventPuzzle
         ?? throw new ArgumentException($"Could not create {nameof(IAdventPuzzle)} from type {type}");
+
+    public static string Year(Type type) =>
+        type.IsAssignableTo(typeof(IAdventPuzzle)) ? type.Namespace?.Split('.')[^1][^4..] ?? string.Empty : string.Empty;
+    public static string Day(Type type) =>
+        type.IsAssignableTo(typeof(IAdventPuzzle)) ? type.Name[^2..] : string.Empty;
 }

--- a/Advent of Code/InputHelper.cs
+++ b/Advent of Code/InputHelper.cs
@@ -7,10 +7,9 @@ public partial class InputHelper : IDisposable
     private readonly StreamReader reader;
     private bool _disposed;
 
-    public static async Task<InputHelper?> Create(Type type, string? sample = null)
+    public static InputHelper? Create(Type type, string? sample = null)
     {
-        var (year, day) = (int.Parse(type.Namespace?.Split('.')[^1][^4..] ?? "0"), int.Parse(type.Name[^2..]));
-        var file = new FileInfo($@"Advent{year}\input\{sample ?? string.Empty}{day:D2}.txt");
+        var file = new FileInfo($@"Advent{IAdventPuzzle.Year(type)}\input\{sample ?? string.Empty}{IAdventPuzzle.Day(type)}.txt");
         return file.Exists ? new(file.Open(options)) : null;
     }
 
@@ -20,6 +19,11 @@ public partial class InputHelper : IDisposable
     {
         for (var line = reader.ReadLine(); line is not null; line = reader.ReadLine())
             action(line);
+    }
+    public IEnumerable<string> EachLine()
+    {
+        for (var line = reader.ReadLine(); line is not null; line = reader.ReadLine())
+            yield return line;
     }
     public IEnumerable<T> EachLine<T>(Func<string, T> function)
     {
@@ -45,7 +49,7 @@ public partial class InputHelper : IDisposable
     }
     public IEnumerable<T> EachSection<T>(Func<IEnumerable<string>, T> function)
     {
-        return DoubleLineBreak().Split(reader.ReadToEnd())
+        return DoubleLineBreak().Split(reader.ReadToEnd().TrimEnd())
             .Select(section => section.Split("\n"))
             .Select(function);
     }

--- a/AdventTest/AdventTests.cs
+++ b/AdventTest/AdventTests.cs
@@ -1,0 +1,28 @@
+﻿using Advent_of_Code;
+using Xunit;
+
+namespace AdventTest;
+
+public static class AdventTests
+{
+    [Theory]
+    [ClassData(typeof(AdventSolutions2022))]
+    [ClassData(typeof(AdventSolutions2024))]
+    public static void TestPuzzle(Type day, int part, string solution)
+    {
+        using var input = InputHelper.Create(day);
+        var puzzle = IAdventPuzzle.Solver(day, part);
+        Assert.Equal(solution, puzzle.Solve(input!));
+    }
+}
+
+public abstract class AdventSolutions : TheoryData<Type, int, string>
+{
+    protected abstract Dictionary<Type, IEnumerable<string>> Solutions { get; }
+    protected AdventSolutions() => AddRange(
+        Solutions.SelectMany(kvp => kvp.Value.Select((x, i) => new TheoryDataRow<Type, int, string>(kvp.Key, i + 1, x)
+            .WithTestDisplayName($"{IAdventPuzzle.Year(kvp.Key)}.{IAdventPuzzle.Day(kvp.Key)}.{i + 1}")
+            .WithTrait("Year", IAdventPuzzle.Year(kvp.Key))
+            .WithTrait("Day", IAdventPuzzle.Day(kvp.Key))
+            .WithTrait("part", $"{i + 1}"))));
+}

--- a/AdventTest/AdventTests2022.cs
+++ b/AdventTest/AdventTests2022.cs
@@ -1,0 +1,37 @@
+using Advent_of_Code.Advent2022;
+
+namespace AdventTest;
+
+public class AdventSolutions2022 : AdventSolutions
+{
+    protected override Dictionary<Type, IEnumerable<string>> Solutions => solutions;
+
+    private static readonly Dictionary<Type, IEnumerable<string>> solutions = new()
+    {
+        [typeof(Day01)] = ["66616", "199172"],
+        [typeof(Day02)] = ["13924", "13448"],
+        [typeof(Day03)] = ["7581", "2525"],
+        [typeof(Day04)] = ["547", "843"],
+        [typeof(Day05)] = ["QNHWJVJZW", "BPCZJLFJW"],
+        [typeof(Day06)] = ["1140", "3495"],
+        [typeof(Day07)] = ["1490523", "12390492"],
+        [typeof(Day08)] = ["1825", "235200"],
+        [typeof(Day09)] = [string.Empty, string.Empty],
+        [typeof(Day10)] = [string.Empty, string.Empty],
+        [typeof(Day11)] = [string.Empty, string.Empty],
+        [typeof(Day12)] = [string.Empty, string.Empty],
+        [typeof(Day13)] = [string.Empty, string.Empty],
+        [typeof(Day14)] = [string.Empty, string.Empty],
+        [typeof(Day15)] = [string.Empty, string.Empty],
+        [typeof(Day16)] = [string.Empty, string.Empty],
+        [typeof(Day17)] = [string.Empty, string.Empty],
+        [typeof(Day18)] = [string.Empty, string.Empty],
+        [typeof(Day19)] = [string.Empty, string.Empty],
+        [typeof(Day20)] = [string.Empty, string.Empty],
+        [typeof(Day21)] = [string.Empty, string.Empty],
+        [typeof(Day22)] = [string.Empty, string.Empty],
+        [typeof(Day23)] = [string.Empty, string.Empty],
+        [typeof(Day24)] = [string.Empty, string.Empty],
+        [typeof(Day25)] = [string.Empty]
+    };
+}

--- a/AdventTest/AdventTests2024.cs
+++ b/AdventTest/AdventTests2024.cs
@@ -1,11 +1,11 @@
-using Advent_of_Code;
 using Advent_of_Code.Advent2024;
-using Xunit;
 
 namespace AdventTest;
 
-public static class Advent2024_Should
+public class AdventSolutions2024 : AdventSolutions
 {
+    protected override Dictionary<Type, IEnumerable<string>> Solutions => solutions;
+
     private static readonly Dictionary<Type, IEnumerable<string>> solutions = new()
     {
         [typeof(Day01)] = ["2196996", "23655822"],
@@ -34,19 +34,4 @@ public static class Advent2024_Should
         [typeof(Day24)] = ["61495910098126", "61633350099662"],
         [typeof(Day25)] = ["2950"]
     };
-
-    public static TheoryData<Type, int, string> Solutions() => new(
-        solutions.SelectMany(kvp => kvp.Value.Select((x, i) => new TheoryDataRow<Type, int, string>(kvp.Key, i + 1, x)
-            .WithTestDisplayName($"{kvp.Key.Name[^5..]} part{i + 1} = {x}")
-            .WithTrait("Day", kvp.Key.Name[^2..])
-            .WithTrait("part", $"{i + 1}"))));
-
-    [Theory]
-    [MemberData(nameof(Solutions))]
-    public static async Task TestAll(Type day, int part, string solution)
-    {
-        using var input = await InputHelper.Create(day);
-        var puzzle = IAdventPuzzle.Solver(day, part);
-        Assert.Equal(solution, puzzle.Solve(input!));
-    }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Advent of Code
 
-![Lines of code and total elapsed runtime for each day's puzzles (combined)](Advent2024/aoc2024.png)
+[![Lines of code and total elapsed runtime for each day's puzzles (combined)](Advent%20of%20Code/Advent2024/aoc2024.png)](Advent%20of%20Code/Advent2024)


### PR DESCRIPTION
- [Change tests to use ClassData, to support other years](https://github.com/nasha4/AdventOfCode/commit/8ed4c5a3494761ca2f36c198007c02749141e66f)
- [Add Static IAdventPuzzle helper functions for reflecting Year and Day of a puzzle type](https://github.com/nasha4/AdventOfCode/commit/62b941f7b485e1330cbcf9f9a7b4c659a90399ff)
- [Add default EachLine(), it's common enough](https://github.com/nasha4/AdventOfCode/commit/9051d15e78ba846652821eb0e337910840e9374b)
- [Create nice GridHelper and GridHelper<TItem> alias classes](https://github.com/nasha4/AdventOfCode/commit/acb6b3b239f844a2a639f14d2804193d6d460a60) 
- [Use new GridHelper and InputHelper](https://github.com/nasha4/AdventOfCode/commit/ccf6bc631418802df3d9cf6e4581d5959580737c)
- [Add Advent2022 stubs](https://github.com/nasha4/AdventOfCode/commit/c8a7b8526542222c3960d5f7dfbb72dc75ea3eb9)
- [Convert old Advent2022 solutions to IAdventPuzzle and to use helpers](https://github.com/nasha4/AdventOfCode/commit/c69f281c320e38661a88de524632b594ce05333a)
- [Fix broken link](https://github.com/nasha4/AdventOfCode/commit/75b1a80b4c3fbf5a4607e6486d7c2ab9d5a5fc5f)